### PR TITLE
Add static Noir website prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# noir--site
+# Noir Site
+
+This repo contains a minimal React + Tailwind CSS prototype for the Noir luxury water brand. The implementation is intentionally minimal due to the offline environment. All dependencies are loaded from public CDNs.
+
+## Usage
+
+Open `public/index.html` in a browser with internet access. The landing page features a simple can animation using React and Framer Motion and pulls product plans from `data/flavors.json`.
+
+`public/admin.html` provides a stub admin dashboard that loads the JSON configuration for editing. Saving will require integration with a backend service such as Firebase or Supabase.
+
+## Notes
+
+- This is not a complete production setup. To build a full application, clone the repository with internet access and replace CDN links with locally managed dependencies.
+- Integrate Firebase or Supabase for real feedback storage and authentication.

--- a/data/flavors.json
+++ b/data/flavors.json
@@ -1,0 +1,16 @@
+{
+  "plans": [
+    {
+      "title": "It’s Just Water",
+      "description": "4 cans/week of pure water, subscription model."
+    },
+    {
+      "title": "Signature Flavors",
+      "description": "4 cans/week of best-selling flavors, rotating seasonally."
+    },
+    {
+      "title": "Experimental Flavors",
+      "description": "4 cans/week, 3 known, 1 new. Includes feedback form link."
+    }
+  ]
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Noir Admin</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <div id="admin-root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="scripts/admin.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Noir luxury water brand"> 
+  <title>Noir</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet">
+  <style>
+    body {background-color: #000; color: #fff;}
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/framer-motion/dist/framer-motion.umd.js"></script>
+  <script src="scripts/main.js"></script>
+</body>
+</html>

--- a/public/scripts/admin.js
+++ b/public/scripts/admin.js
@@ -1,0 +1,34 @@
+const { useState, useEffect } = React;
+
+function AdminApp() {
+  const [flavors, setFlavors] = useState('');
+
+  const loadFlavors = () => {
+    fetch('../data/flavors.json')
+      .then(res => res.text())
+      .then(text => setFlavors(text));
+  };
+
+  const saveFlavors = () => {
+    alert('Saving requires backend integration.');
+  };
+
+  useEffect(loadFlavors, []);
+
+  return (
+    React.createElement('div', { className: 'p-6 space-y-4' },
+      React.createElement('h1', { className: 'text-xl font-bold' }, 'Admin Dashboard'),
+      React.createElement('textarea', {
+        className: 'w-full h-64 text-black',
+        value: flavors,
+        onChange: e => setFlavors(e.target.value)
+      }),
+      React.createElement('button', {
+        className: 'bg-gray-800 px-4 py-2 rounded text-white',
+        onClick: saveFlavors
+      }, 'Save (stub)')
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('admin-root')).render(React.createElement(AdminApp));

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,0 +1,52 @@
+const { useState, useEffect } = React;
+const { motion, AnimatePresence } = window['framer-motion'];
+
+function CanAnimation() {
+  return (
+    React.createElement('div', { className: 'flex items-center justify-center h-screen' },
+      React.createElement(motion.div, {
+        initial: { rotate: 0, opacity: 0 },
+        animate: { rotate: 360, opacity: 1 },
+        transition: { duration: 4 },
+        className: 'w-40 h-80 bg-black rounded-lg shadow-lg flex items-center justify-center border border-gray-700'
+      },
+        React.createElement('span', { className: 'text-white text-3xl font-bold' }, 'Noir')
+      )
+    )
+  );
+}
+
+function Plans({ plans }) {
+  return (
+    React.createElement('div', { className: 'flex flex-col md:flex-row justify-center gap-4 p-8' },
+      plans.map((p, idx) =>
+        React.createElement('div', {
+          key: idx,
+          className: 'bg-black/60 backdrop-blur-md border border-gray-600 rounded-xl p-6 shadow-lg w-full md:w-1/3'
+        },
+          React.createElement('h3', { className: 'text-xl font-semibold mb-2' }, p.title),
+          React.createElement('p', { className: 'mb-4' }, p.description),
+          p.title === 'Experimental Flavors' &&
+            React.createElement('a', { href: '#feedback', className: 'underline text-gold-400' }, 'Feedback Form')
+        )
+      )
+    )
+  );
+}
+
+function App() {
+  const [plans, setPlans] = useState([]);
+  useEffect(() => {
+    fetch('../data/flavors.json')
+      .then(res => res.json())
+      .then(data => setPlans(data.plans));
+  }, []);
+  return (
+    React.createElement('div', null,
+      React.createElement(CanAnimation, null),
+      React.createElement(Plans, { plans })
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));


### PR DESCRIPTION
## Summary
- create a minimal Noir landing page and admin page using React via CDN
- implement simple can animation with Framer Motion
- load product plan data from `flavors.json`
- provide stub admin dashboard for editing JSON
- update README with usage instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685122cc745c8328a2ebdee0b06c24ae