### PR TITLE
Improve Noir prototype with Cloudflare-friendly data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# noir--site
+# Noir Site
+
+This repo contains a lightweight React + Tailwind CSS prototype for the Noir luxury water brand. The site runs entirely from static files with dependencies loaded from public CDNs.
+
+## Usage
+
+Open `public/index.html` in a browser with internet access. The landing page now features a spinning can animation that drops to reveal a stylised `ø`. Plan cards are loaded from `data/flavors.json` (served from the `public` folder) and a small feedback form stores submissions in `localStorage`.
+
+`public/admin.html` exposes a password protected dashboard (password `noir`). The editor lets you modify the JSON configuration and saves it to `localStorage`.
+
+### Cloudflare Pages
+
+Deploy the `public` directory as your Pages project. No build step is required.
+Make sure `public/data/flavors.json` is included so the site can load plan
+information.
+
+## Notes
+
+- This is still a browser-only demo. Replace CDN links with local packages and connect a real backend for production use.
+- Integrate Firebase or Supabase for real feedback storage and authentication.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains a lightweight React + Tailwind CSS prototype for the Noir lux
 
 ## Usage
 
-Open `public/index.html` in a browser with internet access. The landing page now features a spinning can animation that drops to reveal a stylised `ø`. Plan cards are loaded from `data/flavors.json` (served from the `public` folder) and a small feedback form stores submissions in `localStorage`.
+Open `public/index.html` in a browser with internet access. The landing page now starts with a placeholder can that spins briefly then fades into the black background. A white `O` with a floating dash appears and animates while the rest of the site loads. Plan cards are pulled from `data/flavors.json` (served from the `public` folder) and a small feedback form stores submissions in `localStorage`.
 
 `public/admin.html` exposes a password protected dashboard (password `noir`). The editor lets you modify the JSON configuration and saves it to `localStorage`.
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Noir Admin</title>
+  <meta name="description" content="Admin dashboard for Noir water site">
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <div id="admin-root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="scripts/admin.js"></script>
+</body>
+</html>

--- a/public/data/flavors.json
+++ b/public/data/flavors.json
@@ -1,0 +1,16 @@
+{
+  "plans": [
+    {
+      "title": "It’s Just Water",
+      "description": "4 cans/week of pure water, subscription model."
+    },
+    {
+      "title": "Signature Flavors",
+      "description": "4 cans/week of best-selling flavors, rotating seasonally."
+    },
+    {
+      "title": "Experimental Flavors",
+      "description": "4 cans/week, 3 known, 1 new. Includes feedback form link."
+    }
+  ]
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Noir luxury water brand">
+  <meta name="keywords" content="Noir, water, luxury, sparkling, beverages">
+  <title>Noir</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet">
+  <style>
+    body {background-color: #000; color: #fff; font-family: Arial, sans-serif;}
+    .gold {color: #d4af37;}
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="feedback"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/framer-motion/dist/framer-motion.umd.js"></script>
+  <script src="scripts/main.js"></script>
+</body>
+</html>

--- a/public/scripts/admin.js
+++ b/public/scripts/admin.js
@@ -1,0 +1,59 @@
+const { useState, useEffect } = React;
+
+function AdminApp() {
+  const [flavors, setFlavors] = useState('');
+  const [password, setPassword] = useState('');
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  const loadFlavors = () => {
+    const stored = localStorage.getItem('flavors');
+    if (stored) {
+      setFlavors(stored);
+    } else {
+      fetch('data/flavors.json')
+        .then(res => res.text())
+        .then(text => setFlavors(text));
+    }
+  };
+
+  const saveFlavors = () => {
+    localStorage.setItem('flavors', flavors);
+    alert('Saved to local storage.');
+  };
+
+  useEffect(loadFlavors, []);
+
+  if (!loggedIn) {
+    return React.createElement('div', { className: 'p-6 space-y-4' },
+      React.createElement('h1', { className: 'text-xl font-bold' }, 'Admin Login'),
+      React.createElement('input', {
+        type: 'password',
+        className: 'text-black p-2',
+        placeholder: 'Password',
+        value: password,
+        onChange: e => setPassword(e.target.value)
+      }),
+      React.createElement('button', {
+        className: 'bg-gray-800 text-white px-4 py-2 rounded',
+        onClick: () => password === 'noir' ? setLoggedIn(true) : alert('Wrong password')
+      }, 'Login')
+    );
+  }
+
+  return (
+    React.createElement('div', { className: 'p-6 space-y-4' },
+      React.createElement('h1', { className: 'text-xl font-bold' }, 'Admin Dashboard'),
+      React.createElement('textarea', {
+        className: 'w-full h-64 text-black',
+        value: flavors,
+        onChange: e => setFlavors(e.target.value)
+      }),
+      React.createElement('button', {
+        className: 'bg-gray-800 px-4 py-2 rounded text-white',
+        onClick: saveFlavors
+      }, 'Save')
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('admin-root')).render(React.createElement(AdminApp));

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,0 +1,97 @@
+const { useState, useEffect } = React;
+const { motion } = window['framer-motion'];
+
+function CanAnimation({ onEnd }) {
+  const [showSymbol, setShowSymbol] = useState(false);
+  return (
+    React.createElement('div', { className: 'flex items-center justify-center h-screen' },
+      showSymbol ?
+        React.createElement(motion.div, {
+          initial: { rotate: -180, opacity: 0 },
+          animate: { rotate: 0, opacity: 1 },
+          transition: { duration: 1 },
+          className: 'text-6xl gold'
+        }, 'ø') :
+        React.createElement(motion.img, {
+          src: 'https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=200&q=80',
+          alt: 'Noir can',
+          initial: { rotate: 0, opacity: 0 },
+          animate: { rotate: 360, opacity: 1, y: [0, 40] },
+          transition: { duration: 4 },
+          onAnimationComplete: () => { setShowSymbol(true); onEnd && onEnd(); },
+          className: 'w-32 h-64 object-cover rounded-lg shadow-2xl border border-gray-700'
+        })
+    )
+  );
+}
+
+function Plans({ plans }) {
+  return (
+    React.createElement('div', { className: 'flex flex-col md:flex-row justify-center gap-4 p-8' },
+      plans.map((p, idx) =>
+        React.createElement('div', {
+          key: idx,
+          className: 'bg-black/60 backdrop-blur-md border border-gray-600 rounded-xl p-6 shadow-lg w-full md:w-1/3'
+        },
+          React.createElement('h3', { className: 'text-xl font-semibold mb-2' }, p.title),
+          React.createElement('p', { className: 'mb-4' }, p.description),
+          p.title === 'Experimental Flavors' &&
+            React.createElement('a', { href: '#feedback', className: 'underline text-gold-400' }, 'Feedback Form')
+        )
+      )
+    )
+  );
+}
+
+function FeedbackForm() {
+  const [name, setName] = useState('');
+  const [notes, setNotes] = useState('');
+  const save = () => {
+    const items = JSON.parse(localStorage.getItem('feedback') || '[]');
+    items.push({ name, notes, date: new Date().toISOString() });
+    localStorage.setItem('feedback', JSON.stringify(items));
+    setName('');
+    setNotes('');
+    alert('Feedback saved locally.');
+  };
+  return (
+    React.createElement('div', { className: 'p-6 space-y-4 max-w-md mx-auto' },
+      React.createElement('h2', { className: 'text-2xl font-semibold mb-2' }, 'Experimental Feedback'),
+      React.createElement('input', {
+        className: 'w-full p-2 text-black rounded',
+        placeholder: 'Name', value: name,
+        onChange: e => setName(e.target.value)
+      }),
+      React.createElement('textarea', {
+        className: 'w-full h-32 text-black rounded p-2',
+        placeholder: 'Comments', value: notes,
+        onChange: e => setNotes(e.target.value)
+      }),
+      React.createElement('button', {
+        className: 'bg-gray-800 text-white px-4 py-2 rounded',
+        onClick: save
+      }, 'Submit')
+    )
+  );
+}
+
+function App() {
+  const [plans, setPlans] = useState([]);
+  const [showPlans, setShowPlans] = useState(false);
+  useEffect(() => {
+    fetch('data/flavors.json')
+      .then(res => res.json())
+      .then(data => setPlans(data.plans));
+  }, []);
+  return (
+    React.createElement('div', null,
+      React.createElement(CanAnimation, { onEnd: () => setShowPlans(true) }),
+      showPlans && React.createElement(Plans, { plans }),
+      React.createElement('div', { id: 'feedback' },
+        React.createElement(FeedbackForm, null)
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -2,25 +2,49 @@ const { useState, useEffect } = React;
 const { motion } = window['framer-motion'];
 
 function CanAnimation({ onEnd }) {
-  const [showSymbol, setShowSymbol] = useState(false);
+  const [phase, setPhase] = useState('can');
+
+  // after a short spin, switch to the loading symbol
+  useEffect(() => {
+    const timer = setTimeout(() => setPhase('symbol'), 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // notify parent when the symbol appears
+  useEffect(() => {
+    if (phase === 'symbol' && onEnd) {
+      const t = setTimeout(onEnd, 1000);
+      return () => clearTimeout(t);
+    }
+  }, [phase, onEnd]);
+
   return (
-    React.createElement('div', { className: 'flex items-center justify-center h-screen' },
-      showSymbol ?
+    React.createElement('div', { className: 'flex items-center justify-center h-screen bg-black' },
+      phase === 'can' ?
         React.createElement(motion.div, {
-          initial: { rotate: -180, opacity: 0 },
-          animate: { rotate: 0, opacity: 1 },
-          transition: { duration: 1 },
-          className: 'text-6xl gold'
-        }, 'ø') :
-        React.createElement(motion.img, {
-          src: 'https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=200&q=80',
-          alt: 'Noir can',
           initial: { rotate: 0, opacity: 0 },
-          animate: { rotate: 360, opacity: 1, y: [0, 40] },
-          transition: { duration: 4 },
-          onAnimationComplete: () => { setShowSymbol(true); onEnd && onEnd(); },
-          className: 'w-32 h-64 object-cover rounded-lg shadow-2xl border border-gray-700'
-        })
+          animate: { rotate: 360, opacity: [1, 1, 0] },
+          transition: { duration: 3 },
+          className: 'w-32 h-64 bg-gray-700 rounded-lg shadow-2xl'
+        }) :
+        React.createElement(motion.div, {
+          className: 'relative w-40 h-40 flex items-center justify-center',
+          initial: { opacity: 0 },
+          animate: { opacity: 1 },
+          transition: { duration: 1 }
+        },
+          React.createElement(motion.div, {
+            className: 'text-white text-7xl',
+            animate: { rotate: 360 },
+            transition: { duration: 4, repeat: Infinity, ease: 'linear' }
+          }, 'O'),
+          React.createElement(motion.div, {
+            className: 'absolute bg-white',
+            style: { width: '80%', height: '4px' },
+            animate: { x: ['-50%', '50%', '-50%'] },
+            transition: { duration: 2, repeat: Infinity, ease: 'easeInOut' }
+          })
+        )
     )
   );
 }


### PR DESCRIPTION
## Summary
- move plan data into `public/data` for easier hosting
- update scripts to load `data/flavors.json`
- document Cloudflare Pages usage and data path

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685122cc745c8328a2ebdee0b06c24ae